### PR TITLE
Added tab stops to place cursor in appropriate location after tag insertion

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -7,12 +7,12 @@ class CompletionProvider {
 		let snippets = [];
 		
 		for (let snippet in htmlSnippets) {
-			let item = new CompletionItem(htmlSnippets[snippet].prefix, CompletionItemKind.File);
-            console.log(htmlSnippets[snippet].description);
+			let item = new CompletionItem(htmlSnippets[snippet].prefix, CompletionItemKind.Tag);
+			console.log(htmlSnippets[snippet].description);
 	
 			item.documentation = htmlSnippets[snippet].description;
 			item.insertText = htmlSnippets[snippet].body;
-			item.tokenize = true;
+			item.insertTextFormat = InsertTextFormat.Snippet;
 			
 			snippets.push(item)
 		}

--- a/Scripts/snippets/snippets.json
+++ b/Scripts/snippets/snippets.json
@@ -8,85 +8,85 @@
   },
   "a": {
     "prefix": "a",
-    "body": "<a href=\"\"></a>",
+    "body": "<a href=\"$1\">$0</a>",
     "description": "HTML - Defines a hyperlink"
   },
   "abbr": {
     "prefix": "abbr",
-    "body": "<abbr title=\"\"></abbr>",
+    "body": "<abbr title=\"$1\">$0</abbr>",
     "description": "HTML - Defines an abbreviation"
   },
   "address": {
     "prefix": "address",
     "body": [
-      "<address>\n</address>"
+      "<address>\n$0</address>"
     ],
     "description": "HTML - Defines an address element"
   },
   "area": {
     "prefix": "area",
-    "body": "<area shape=\"\" coords=\"\" href=\"\" alt=\"\">",
+    "body": "<area shape=\"$1\" coords=\"$2\" href=\"$3\" alt=\"$4\">",
     "description": "HTML - Defines an area inside an image map"
   },
   "article": {
     "prefix": "article",
     "body": [
-      "<article>\n</article>"
+      "<article>\n$0</article>"
     ],
     "description": "HTML - Defines an article"
   },
   "aside": {
     "prefix": "aside",
     "body": [
-      "<aside>\n</aside>"
+      "<aside>\n$0</aside>"
     ],
     "description": "HTML - Defines content aside from the page content"
   },
   "audio": {
     "prefix": "audio",
     "body": [
-      "<audio controls>\n</audio>"
+      "<audio controls>\n$0</audio>"
     ],
     "description": "HTML - Defines sounds content"
   },
   "b": {
     "prefix": "b",
-    "body": "<b></b>",
+    "body": "<b>$0</b>",
     "description": "HTML - Defines bold text"
   },
   "base": {
     "prefix": "base",
-    "body": "<base href=\"\" target=\"\">",
+    "body": "<base href=\"$1\" target=\"$2\">$0",
     "description": "HTML - Defines a base URL for all the links in a page"
   },
   "bdi": {
     "prefix": "bdi",
-    "body": "<bdi></bdi>",
+    "body": "<bdi>$0</bdi>",
     "description": "HTML - Used to isolate text that is of unknown directionality"
   },
   "bdo": {
     "prefix": "bdo",
     "body": [
-      "<bdo dir=\"\">\n</bdo>"
+      "<bdo dir=\"$1\">\n$0</bdo>"
     ],
     "description": "HTML - Defines the direction of text display"
   },
   "big": {
     "prefix": "big",
-    "body": "<big></big>",
+    "body": "<big>$0</big>",
     "description": "HTML - Used to make text bigger"
   },
   "blockquote": {
     "prefix": "blockquote",
     "body": [
-      "<blockquote cite=\"\">\n</blockquote>"
+      "<blockquote cite=\"$1\">\n$0</blockquote>"
     ],
     "description": "HTML - Defines a long quotation"
   },
   "body": {
     "prefix": "body",
     "body": [
-      "<body>\n</body>"
+      "<body>\n$0</body>"
     ],
     "description": "HTML - Defines the body element"
   },
@@ -97,27 +97,27 @@
   },
   "button": {
     "prefix": "button",
-    "body": "<button type=\"\"></button>",
+    "body": "<button type=\"$1\">$0</button>",
     "description": "HTML - Defines a push button"
   },
   "canvas": {
     "prefix": "canvas",
-    "body": "<canvas id=\"\"></canvas>",
+    "body": "<canvas id=\"$1\">$0</canvas>",
     "description": "HTML - Defines graphics"
   },
   "caption": {
     "prefix": "caption",
-    "body": "<caption></caption>",
+    "body": "<caption>$0</caption>",
     "description": "HTML - Defines a table caption"
   },
   "cite": {
     "prefix": "cite",
-    "body": "<cite></cite>",
+    "body": "<cite>$0</cite>",
     "description": "HTML - Defines a citation"
   },
   "code": {
     "prefix": "code",
-    "body": "<code></code>",
+    "body": "<code>$0</code>",
     "description": "HTML - Defines computer code text"
   },
   "col": {
@@ -128,159 +128,159 @@
   "colgroup": {
     "prefix": "colgroup",
     "body": [
-      "<colgroup>\n</colgroup>"
+      "<colgroup>\n$0</colgroup>"
     ],
     "description": "HTML - Defines group of table columns"
   },
   "command": {
     "prefix": "command",
-    "body": "<command></command>",
+    "body": "<command>$0</command>",
     "description": "HTML - Defines a command button [not supported]"
   },
   "datalist": {
     "prefix": "datalist",
     "body": [
-      "<datalist>\n</datalist>"
+      "<datalist>\n$0</datalist>"
     ],
     "description": "HTML - Defines a dropdown list"
   },
   "dd": {
     "prefix": "dd",
-    "body": "<dd></dd>",
+    "body": "<dd>$0</dd>",
     "description": "HTML - Defines a definition description"
   },
   "del": {
     "prefix": "del",
-    "body": "<del></del>",
+    "body": "<del>$0</del>",
     "description": "HTML - Defines deleted text"
   },
   "details": {
     "prefix": "details",
     "body": [
-      "<details>\n</details>"
+      "<details>\n$0</details>"
     ],
     "description": "HTML - Defines details of an element"
   },
   "dialog": {
     "prefix": "dialog",
-    "body": "<dialog></dialog>",
+    "body": "<dialog>$0</dialog>",
     "description": "HTML - Defines a dialog (conversation)"
   },
   "dfn": {
     "prefix": "dfn",
-    "body": "<dfn></dfn>",
+    "body": "<dfn>$0</dfn>",
     "description": "HTML - Defines a definition term"
   },
   "div": {
     "prefix": "div",
     "body": [
-      "<div>\n</div>"
+      "<div>\n$0</div>"
     ],
     "description": "HTML - Defines a section in a document"
   },
   "dl": {
     "prefix": "dl",
     "body": [
-      "<dl>\n</dl>"
+      "<dl>\n$0</dl>"
     ],
     "description": "HTML - Defines a definition list"
   },
   "dt": {
     "prefix": "dt",
-    "body": "<dt></dt>",
+    "body": "<dt>$0</dt>",
     "description": "HTML - Defines a definition term"
   },
   "em": {
     "prefix": "em",
-    "body": "<em></em>",
+    "body": "<em>$0</em>",
     "description": "HTML - Defines emphasized text"
   },
   "embed": {
     "prefix": "embed",
-    "body": "<embed src=\"\">",
+    "body": "<embed src=\"$1\">$0",
     "description": "HTML - Defines external interactive content ot plugin"
   },
   "fieldset": {
     "prefix": "fieldset",
     "body": [
-      "<fieldset>\n</fieldset>"
+      "<fieldset>\n$0</fieldset>"
     ],
     "description": "HTML - Defines a fieldset"
   },
   "figcaption": {
     "prefix": "figcaption",
-    "body": "<figcaption></figcaption>",
+    "body": "<figcaption>$0</figcaption>",
     "description": "HTML - Defines a caption for a figure"
   },
   "figure": {
     "prefix": "figure",
     "body": [
-      "<figure>\n</figure>"
+      "<figure>\n$0</figure>"
     ],
     "description": "HTML - Defines a group of media content, and their caption"
   },
   "footer": {
     "prefix": "footer",
     "body": [
-      "<footer>\n</footer>"
+      "<footer>\n$0</footer>"
     ],
     "description": "HTML - Defines a footer for a section or page"
   },
   "form": {
     "prefix": "form",
     "body": [
-      "<form>\n</form>"
+      "<form>\n$0</form>"
     ],
     "description": "HTML - Defines a form"
   },
   "h1": {
     "prefix": "h1",
-    "body": "<h1></h1>",
+    "body": "<h1>$0</h1>",
     "description": "HTML - Defines header 1"
   },
   "h2": {
     "prefix": "h2",
-    "body": "<h2></h2>",
+    "body": "<h2>$0</h2>",
     "description": "HTML - Defines header 2"
   },
   "h3": {
     "prefix": "h3",
-    "body": "<h3></h3>",
+    "body": "<h3>$0</h3>",
     "description": "HTML - Defines header 3"
   },
   "h4": {
     "prefix": "h4",
-    "body": "<h4></h4>",
+    "body": "<h4>$0</h4>",
     "description": "HTML - Defines header 4"
   },
   "h5": {
     "prefix": "h5",
-    "body": "<h5></h5>",
+    "body": "<h5>$0</h5>",
     "description": "HTML - Defines header 5"
   },
   "h6": {
     "prefix": "h6",
-    "body": "<h6></h6>",
+    "body": "<h6>$0</h6>",
     "description": "HTML - Defines header 6"
   },
   "head": {
     "prefix": "head",
     "body": [
-      "<head>\n</head>"
+      "<head>\n$0</head>"
     ],
     "description": "HTML - Defines information about the document"
   },
   "header": {
     "prefix": "header",
     "body": [
-      "<header>\n</header>"
+      "<header>\n$0</header>"
     ],
     "description": "HTML - Defines a header for a section of page"
   },
   "hgroup": {
     "prefix": "hgroup",
     "body": [
-      "<hgroup>\n</hgroup>"
+      "<hgroup>\n$0</hgroup>"
     ],
     "description": "HTML - Defines information about a section in a document"
   },
@@ -292,357 +292,355 @@
   "html": {
     "prefix": "html",
     "body": [
-      "<html>\n</html>"
+      "<html>\n$0</html>"
     ],
     "description": "HTML - Defines an html document"
   },
   "html5": {
     "prefix": "html5",
     "body": [
-      "<!DOCTYPE html>\n<html lang=\"en\">\n\t<head>\n\t\t<title></title>\n\t\t<meta charset=\"UTF-8\">\n\t\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\t\t<link href=\"css/style.css\" rel=\"stylesheet\">\n\t</head>\n\t<body>\n\t</body>\n</html>\n",
+      "<!DOCTYPE html>\n<html lang=\"en\">\n\t<head>\n\t\t<title>$1</title>\n\t\t<meta charset=\"UTF-8\">\n\t\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\t\t<link href=\"css/style.css\" rel=\"stylesheet\">\n\t</head>\n\t<body>\n\t</body>\n$0</html>\n",
     ],
     "description": "HTML - Defines a template for a html5 document"
   },
   "i": {
     "prefix": "i",
-    "body": "<i></i>",
+    "body": "<i>$0</i>",
     "description": "HTML - Defines italic text"
   },
   "iframe": {
     "prefix": "iframe",
-    "body": "<iframe src=\"\"></iframe>",
+    "body": "<iframe src=\"\">$0</iframe>",
     "description": "HTML - Defines an inline sub window"
   },
   "img": {
     "prefix": "img",
-    "body": "<img src=\"\" alt=\"\">",
+    "body": "<img src=\"$1\" alt=\"$0\">",
     "description": "HTML - Defines an image"
   },
   "input": {
     "prefix": "input",
-    "body": "<input type=\"\" name=\"\" value=\"\">",
+    "body": "<input type=\"$1\" name=\"$2\" value=\"$3\">$0",
     "description": "HTML - Defines an input field"
   },
   "ins": {
     "prefix": "ins",
-    "body": "<ins></ins>",
+    "body": "<ins>$0</ins>",
     "description": "HTML - Defines inserted text"
   },
   "keygen": {
     "prefix": "keygen",
-    "body": "<keygen name=\"\">",
+    "body": "<keygen name=\"$1\">$0",
     "description": "HTML - Defines a generated key in a form"
   },
   "kbd": {
     "prefix": "kbd",
-    "body": "<kbd></kbd>",
+    "body": "<kbd>$0</kbd>",
     "description": "HTML - Defines keyboard text"
   },
   "label": {
     "prefix": "label",
-    "body": "<label for=\"\"></label>",
+    "body": "<label for=\"$1\">$2</label>$0",
     "description": "HTML - Defines an inline window"
   },
   "legend": {
     "prefix": "legend",
-    "body": "<legend></legend>",
+    "body": "<legend>$0</legend>",
     "description": "HTML - Defines a title in a fieldset"
   },
   "li": {
     "prefix": "li",
-    "body": "<li></li>",
+    "body": "<li>$0</li>",
     "description": "HTML - Defines a list item"
   },
   "link": {
     "prefix": "link",
-    "body": "<link rel=\"\" type=\"\" href=\"\">",
+    "body": "<link rel=\"$1\" type=\"$2\" href=\"$3\">$0",
     "description": "HTML - Defines a resource reference"
   },
   "main": {
     "prefix": "main",
     "body": [
-      "<main>\n</main>"
+      "<main>\n$0</main>"
     ],
     "description": "HTML - Defines an image map"
   },
   "map": {
     "prefix": "map",
     "body": [
-      "<map name=\"\">\n</map>"
+      "<map name=\"$1\">\n$0</map>"
     ],
     "description": "HTML - Defines an image map"
   },
   "mark": {
     "prefix": "mark",
-    "body": "<mark></mark>",
+    "body": "<mark>$0</mark>",
     "description": "HTML - Defines marked text"
   },
   "menu": {
     "prefix": "menu",
     "body": [
-      "<menu>\n</menu>"
+      "<menu>\n$0</menu>"
     ],
     "description": "HTML - Defines a menu list"
   },
   "menuitem": {
     "prefix": "menuitem",
-    "body": "<menuitem></menuitem>",
+    "body": "<menuitem>$0</menuitem>",
     "description": "HTML - Defines a menu item [firefox only]"
   },
   "meta": {
     "prefix": "meta",
-    "body": "<meta name=\"\" content=\"\">",
+    "body": "<meta name=\"$1\" content=\"$2\">",
     "description": "HTML - Defines meta information"
   },
   "meter": {
     "prefix": "meter",
-    "body": "<meter value=\"\"></meter>",
+    "body": "<meter value=\"$1\">$0</meter>",
     "description": "HTML - Defines measurement within a predefined range"
   },
   "nav": {
     "prefix": "nav",
     "body": [
-      "<nav>\n</nav>"
+      "<nav>\n$0</nav>"
     ],
     "description": "HTML - Defines navigation links"
   },
   "noscript": {
     "prefix": "noscript",
     "body": [
-      "<noscript>\n</noscript>"
+      "<noscript>\n$0</noscript>"
     ],
     "description": "HTML - Defines a noscript section"
   },
   "object": {
     "prefix": "object",
-    "body": "<object width=\"\" height=\"\" data=\"\"></object>",
+    "body": "<object width=\"$1\" height=\"$2\" data=\"$3\">$0</object>",
     "description": "HTML - Defines an embedded object"
   },
   "ol": {
     "prefix": "ol",
     "body": [
-      "<ol>\n</ol>"
+      "<ol>\n$0</ol>"
     ],
     "description": "HTML - Defines an ordered list"
   },
   "optgroup": {
     "prefix": "optgroup",
     "body": [
-      "<optgroup>\n</optgroup>"
+      "<optgroup>\n$0</optgroup>"
     ],
     "description": "HTML - Defines an option group"
   },
   "option": {
     "prefix": "option",
-    "body": "<option value=\"\"></option>",
+    "body": "<option value=\"$1\">$0</option>",
     "description": "HTML - Defines an option in a drop-down list"
   },
   "output": {
     "prefix": "output",
-    "body": "<output name=\"\" for=\"\"></output>",
+    "body": "<output name=\"$1\" for=\"$2\">$0</output>",
     "description": "HTML - Defines some types of output"
   },
   "p": {
     "prefix": "p",
-    "body": "<p></p>",
+    "body": "<p>$0</p>",
     "description": "HTML - Defines a paragraph"
   },
   "param": {
     "prefix": "param",
-    "body": "<param name=\"\" value=\"\">",
+    "body": "<param name=\"$1\" value=\"$2\">$0",
     "description": "HTML - Defines a parameter for an object"
   },
   "pre": {
     "prefix": "pre",
     "body": [
-      "<pre></pre>"
+      "<pre>$0</pre>"
     ],
     "description": "HTML - Defines preformatted text"
   },
   "progress": {
     "prefix": "progress",
-    "body": "<progress value=\"\" max=\"\"></progress>",
+    "body": "<progress value=\"$1\" max=\"$2\">$0</progress>",
     "description": "HTML - Defines progress of a task of any kind"
   },
   "q": {
     "prefix": "q",
-    "body": "<q></q>",
+    "body": "<q>$0</q>",
     "description": "HTML - Defines a short quotation"
   },
   "rp": {
     "prefix": "rp",
-    "body": "<rp></rp>",
+    "body": "<rp>$0</rp>",
     "description": "HTML - Used in ruby annotations to define what to show browsers that do not support the ruby element"
   },
   "rt": {
     "prefix": "rt",
-    "body": "<rt></rt>",
+    "body": "<rt>$0</rt>",
     "description": "HTML - Defines explanation to ruby annotations"
   },
   "ruby": {
     "prefix": "ruby",
     "body": [
-      "<ruby>\n</ruby>"
+      "<ruby>\n$0</ruby>"
     ],
     "description": "HTML - Defines ruby annotations"
   },
   "s": {
     "prefix": "s",
-    "body": "<s></s>",
+    "body": "<s>$0</s>",
     "description": "HTML - Used to define strikethrough text"
   },
   "samp": {
     "prefix": "samp",
-    "body": "<samp></samp>",
+    "body": "<samp>$0</samp>",
     "description": "HTML - Defines sample computer code"
   },
   "script": {
     "prefix": "script",
     "body": [
-      "<script>\n</script>"
+      "<script>\n$0</script>"
     ],
     "description": "HTML - Defines a script"
   },
   "section": {
     "prefix": "section",
     "body": [
-      "<section>\n</section>"
+      "<section>\n$0</section>"
     ],
     "description": "HTML - Defines a section"
   },
   "select": {
     "prefix": "select",
     "body": [
-      "<select>\n</select>"
+      "<select>\n$0</select>"
     ],
     "description": "HTML - Defines a selectable list"
   },
   "small": {
     "prefix": "small",
-    "body": "<small></small>",
+    "body": "<small>$0</small>",
     "description": "HTML - Defines small text"
   },
   "source": {
     "prefix": "source",
-    "body": "<source src=\"\" type=\"\">",
+    "body": "<source src=\"$1\" type=\"$2\">$0",
     "description": "HTML - Defines media resource"
   },
   "span": {
     "prefix": "span",
-    "body": "<span></span>",
+    "body": "<span>$0</span>",
     "description": "HTML - Defines a section in a document"
   },
   "strong": {
     "prefix": "strong",
-    "body": "<strong></strong>",
+    "body": "<strong>$0</strong>",
     "description": "HTML - Defines strong text"
   },
   "style": {
     "prefix": "style",
     "body": [
-      "<style>\n</style"
+      "<style>\n$0</style>"
     ],
     "description": "HTML - Defines a style definition"
   },
   "sub": {
     "prefix": "sub",
-    "body": "<sub></sub>",
+    "body": "<sub>$0</sub>",
     "description": "HTML - Defines sub-scripted text"
   },
   "sup": {
     "prefix": "sup",
-    "body": "<sup></sup>",
+    "body": "<sup>$0</sup>",
     "description": "HTML - Defines super-scripted text"
   },
   "summary": {
     "prefix": "summary",
-    "body": "<summary></summary>",
+    "body": "<summary>$0</summary>",
     "description": "HTML - Defines a visible heading for the detail element [limited support]"
   },
   "table": {
     "prefix": "table",
     "body": [
-      "<table>\n</table>"
+      "<table>\n$0</table>"
     ],
     "description": "HTML - Defines a table"
   },
   "tbody": {
     "prefix": "tbody",
     "body": [
-      "<tbody>\n</tbody>"
+      "<tbody>\n$0</tbody>"
     ],
     "description": "HTML - Defines a table body"
   },
   "td": {
     "prefix": "td",
-    "body": "<td></td>",
+    "body": "<td>$0</td>",
     "description": "HTML - Defines a table cell"
   },
   "textarea": {
     "prefix": "textarea",
-    "body": "<textarea rows=\"\" cols=\"\"></textarea>",
+    "body": "<textarea rows=\"$1\" cols=\"$2\">$0</textarea>",
     "description": "HTML - Defines a text area"
   },
   "tfoot": {
     "prefix": "tfoot",
     "body": [
-      "<tfoot>\n</tfoot>"
+      "<tfoot>\n$0</tfoot>"
     ],
     "description": "HTML - Defines a table footer"
   },
   "thead": {
     "prefix": "thead",
     "body": [
-      "<thead>\n</thead>"
+      "<thead>\n$0</thead>"
     ],
     "description": "HTML - Defines a table head"
   },
   "th": {
     "prefix": "th",
-    "body": "<th></th>",
+    "body": "<th>$0</th>",
     "description": "HTML - Defines a table header"
   },
   "time": {
     "prefix": "time",
-    "body": "<time datetime=\"\"></time>",
+    "body": "<time datetime=\"$1\">$0</time>",
     "description": "HTML - Defines a date/time"
   },
   "title": {
     "prefix": "title",
-    "body": "<title></title>",
+    "body": "<title>$0</title>",
     "description": "HTML - Defines the document title"
   },
   "tr": {
     "prefix": "tr",
-    "body": "<tr></tr>",
+    "body": "<tr>$0</tr>",
     "description": "HTML - Defines a table row"
   },
   "track": {
     "prefix": "track",
-    "body": "<track src=\"\" kind=\"\" srclang=\"\" label=\"\">",
+    "body": "<track src=\"$1\" kind=\"$2\" srclang=\"$3\" label=\"$4\">$0",
     "description": "HTML - Defines a table row"
   },
   "u": {
     "prefix": "u",
-    "body": "<u></u>",
+    "body": "<u>$0</u>",
     "description": "HTML - Used to define underlined text"
   },
   "ul": {
     "prefix": "ul",
-    "body": [
-      "<ul>\n</ul>"
-    ],
+    "body": "<ul>\n$0</ul>",
     "description": "HTML - Defines an unordered list"
   },
   "var": {
     "prefix": "var",
-    "body": "<var></var>",
+    "body": "<var>$0</var>",
     "description": "HTML - Defines a variable"
   },
   "video": {
     "prefix": "video",
     "body": [
-      "<video width=\"\" height=\"\" controls>\n</video>"
+      "<video width=\"$1\" height=\"$2\" controls>\n$0</video>"
     ],
     "description": "HTML - Defines a video"
   }


### PR DESCRIPTION
Addressing Issue #1 

Modified main.js to honor tab stops found in the snippets.json file.

Modified snippets.json to include tab stops on each tag where appropriate.